### PR TITLE
Feat: Toggle visibility of dotfiles on frontend

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -11,7 +11,7 @@
         <span>{{ $t("sidebar.myFiles") }}</span>
       </button>
 
-      <div v-if="user.perm.create">
+      <div v-if="user.perm.create && isListing">
         <button
           @click="$store.commit('showHover', 'newDir')"
           class="action"
@@ -30,6 +30,19 @@
         >
           <i class="material-icons">note_add</i>
           <span>{{ $t("sidebar.newFile") }}</span>
+        </button>
+      </div>
+
+      <div>
+        <button
+            v-if="isListing && !userHiddenDotfiles"
+            class="action"
+            @click="toggleDotfiles"
+            :aria-label="$t('sidebar.dotfiles')"
+            :title="this.$store.state.showDotfiles ? $t('sidebar.dotfiles_hide') : $t('sidebar.dotfiles_show')"
+        >
+          <i class="material-icons">{{ toggleDotfilesIcon }}</i>
+          <span>{{ $t("sidebar.dotfiles") }}</span>
         </button>
       </div>
 
@@ -133,7 +146,7 @@ export default {
   },
   computed: {
     ...mapState(["user"]),
-    ...mapGetters(["isLogged"]),
+    ...mapGetters(["isLogged", "isListing"]),
     active() {
       return this.$store.state.show === "sidebar";
     },
@@ -142,6 +155,12 @@ export default {
     disableExternal: () => disableExternal,
     disableUsedPercentage: () => disableUsedPercentage,
     canLogout: () => !noAuth && loginPage,
+    toggleDotfilesIcon() {
+      return this.$store.state.showDotfiles ? "visibility" : "visibility_off";
+    },
+    userHiddenDotfiles() {
+      return this.user.hideDotfiles;
+    },
   },
   asyncComputed: {
     usage: {
@@ -179,6 +198,9 @@ export default {
     toSettings() {
       this.$router.push({ path: "/settings" }, () => {});
       this.$store.commit("closeHovers");
+    },
+    toggleDotfiles() {
+      this.$store.commit("toggleDotfiles", true);
     },
     help() {
       this.$store.commit("showHover", "help");

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="item"
+    :class="{ item: true, dotfile: this.isDotFile, hidden: this.isDotFile && !showDotfiles }"
     role="button"
     tabindex="0"
     :draggable="isDraggable"
@@ -61,7 +61,7 @@ export default {
     "path",
   ],
   computed: {
-    ...mapState(["user", "selected", "req", "jwt"]),
+    ...mapState(["user", "selected", "req", "jwt", "showDotfiles"]),
     ...mapGetters(["selectedCount"]),
     singleClick() {
       return this.readOnly == undefined && this.user.singleClick;
@@ -93,6 +93,9 @@ export default {
     },
     isThumbsEnabled() {
       return enableThumbs;
+    },
+    isDotFile: function () {
+      return this.name[0] === ".";
     },
   },
   methods: {

--- a/frontend/src/css/listing.css
+++ b/frontend/src/css/listing.css
@@ -69,6 +69,10 @@ body.rtl #listing {
   vertical-align: bottom;
 }
 
+#listing .item.dotfile.hidden {
+  display: none;
+}
+
 .message {
   text-align: center;
   font-size: 2em;

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -249,6 +249,9 @@
     "users": "Users"
   },
   "sidebar": {
+    "dotfiles": "Dotfiles",
+    "dotfiles_show": "Dotfiles are hidden, click to show them",
+    "dotfiles_hide": "Dotfiles are shown, click to hide them",
     "help": "Help",
     "hugoNew": "Hugo New",
     "login": "Login",

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -23,6 +23,7 @@ const state = {
   show: null,
   showShell: false,
   showConfirm: null,
+  showDotfiles: true,
 };
 
 export default new Vuex.Store({

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -9,6 +9,9 @@ const mutations = {
   toggleShell: (state) => {
     state.showShell = !state.showShell;
   },
+  toggleDotfiles: (state) => {
+    state.showDotfiles = !state.showDotfiles;
+  },
   showHover: (state, value) => {
     if (typeof value !== "object") {
       state.show = value;


### PR DESCRIPTION
Add ability to toggle display of hidden files without setting on server-side.

The original 'show/hide hidden files' setting is applied on server-side and completely removes hidden files from the directory listings returned to the frontend. This feature allows toggling on or off hidden files display in a listing view w/o changing the setting.